### PR TITLE
Add api for sendinge/receiving data from frontend server

### DIFF
--- a/src/main/java/com/atable/alcholknowledge/controller/CorkageInfoController.java
+++ b/src/main/java/com/atable/alcholknowledge/controller/CorkageInfoController.java
@@ -2,11 +2,12 @@ package com.atable.alcholknowledge.controller;
 
 import com.atable.alcholknowledge.model.CorkageInfo;
 import com.atable.alcholknowledge.service.CorkageInfoService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -21,6 +22,37 @@ public class CorkageInfoController {
         this.corkageInfoService = corkageInfoService;
     }
 
+    @CrossOrigin(origins = "*", allowedHeaders = "*")
+    @GetMapping("/api/corkage-info/list")
+    @ResponseBody
+    public String ckInfoListToJson() throws JsonProcessingException {
+        List<CorkageInfo> stores = corkageInfoService.findCkInfos();
+        ObjectMapper mapper = new ObjectMapper();
+        String json = "";
+        try {
+            json = mapper.writeValueAsString(stores);
+        }
+        catch (Exception e) {
+            System.out.println("error : " + e);
+        }
+        return json;
+    }
+
+    @CrossOrigin(origins = "*", allowedHeaders = "*")
+    @PostMapping("api/corkage-info/new")
+    public String createCkInfoFromJson(@RequestBody CorkageInfoForm ckInfoForm) throws JsonProcessingException {
+        CorkageInfo corkageInfo = new CorkageInfo();
+        corkageInfo.setAddr(ckInfoForm.getAddr());
+        corkageInfo.setDesc(ckInfoForm.getDesc());
+        corkageInfo.setDateCreate(LocalDateTime.now());
+        corkageInfoService.register(corkageInfo);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        System.out.println(objectMapper.writeValueAsString(ckInfoForm));
+
+        return "redirect:/corkage-store/list";
+    }
+
     @GetMapping("/corkage-info/new")
     public String createForm() {
         return "corkage/createCkInfoForm";
@@ -31,7 +63,6 @@ public class CorkageInfoController {
         CorkageInfo corkageInfo = new CorkageInfo();
         corkageInfo.setAddr(ckInfoForm.getAddr());
         corkageInfo.setDesc(ckInfoForm.getDesc());
-
         corkageInfo.setDateCreate(LocalDateTime.now());
         corkageInfoService.register(corkageInfo);
         return "redirect:/corkage-store/list";

--- a/src/main/java/com/atable/alcholknowledge/controller/CorkageInfoController.java
+++ b/src/main/java/com/atable/alcholknowledge/controller/CorkageInfoController.java
@@ -7,11 +7,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 
 @Controller
@@ -30,7 +27,7 @@ public class CorkageInfoController {
     }
 
     @PostMapping("/corkage-info/new")
-    public String create(CkInfoForm ckInfoForm) {
+    public String create(CorkageInfoForm ckInfoForm) {
         CorkageInfo corkageInfo = new CorkageInfo();
         corkageInfo.setAddr(ckInfoForm.getAddr());
         corkageInfo.setDesc(ckInfoForm.getDesc());

--- a/src/main/java/com/atable/alcholknowledge/controller/CorkageInfoForm.java
+++ b/src/main/java/com/atable/alcholknowledge/controller/CorkageInfoForm.java
@@ -1,6 +1,6 @@
 package com.atable.alcholknowledge.controller;
 
-public class CkInfoForm {
+public class CorkageInfoForm {
     private String addr;
     private String desc;
 

--- a/src/main/java/com/atable/alcholknowledge/controller/CorkageStoreController.java
+++ b/src/main/java/com/atable/alcholknowledge/controller/CorkageStoreController.java
@@ -34,7 +34,7 @@ public class CorkageStoreController {
     }
 
     @PostMapping("/corkage-store/new")
-    public String create(CkStoreForm ckStoreForm) {
+    public String create(CorkageStoreForm ckStoreForm) {
         CorkageStore corkageStore = new CorkageStore();
 
         corkageStore.setRequiredValue(ckStoreForm.getName(), ckStoreForm.getAddr());

--- a/src/main/java/com/atable/alcholknowledge/controller/CorkageStoreController.java
+++ b/src/main/java/com/atable/alcholknowledge/controller/CorkageStoreController.java
@@ -4,12 +4,12 @@ import com.atable.alcholknowledge.model.CorkageInfo;
 import com.atable.alcholknowledge.model.CorkageStore;
 import com.atable.alcholknowledge.service.CorkageInfoService;
 import com.atable.alcholknowledge.service.CorkageStoreService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -24,6 +24,18 @@ public class CorkageStoreController {
     public CorkageStoreController(CorkageStoreService corkageStoreService, CorkageInfoService corkageInfoService) {
         this.corkageStoreService = corkageStoreService;
         this.corkageInfoService = corkageInfoService;
+    }
+
+    @CrossOrigin(origins = "*", allowedHeaders = "*")
+    @GetMapping("/api/corkage-store/list")
+    @ResponseBody
+    public String ckStoreListToJson() throws JsonProcessingException {
+        List<CorkageStore> stores = corkageStoreService.findCkStores();
+        ObjectMapper objectMapper = new ObjectMapper();
+        String json = "";
+        json = objectMapper.writeValueAsString(stores);
+
+        return json;
     }
 
     @GetMapping("/corkage-store/new")

--- a/src/main/java/com/atable/alcholknowledge/controller/CorkageStoreForm.java
+++ b/src/main/java/com/atable/alcholknowledge/controller/CorkageStoreForm.java
@@ -1,6 +1,6 @@
 package com.atable.alcholknowledge.controller;
 
-public class CkStoreForm {
+public class CorkageStoreForm {
     private String name;
     private String addr;
     private String desc;

--- a/src/main/java/com/atable/alcholknowledge/model/CorkageInfo.java
+++ b/src/main/java/com/atable/alcholknowledge/model/CorkageInfo.java
@@ -1,5 +1,10 @@
 package com.atable.alcholknowledge.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import org.hibernate.annotations.CreationTimestamp;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 
@@ -27,7 +32,9 @@ public class CorkageInfo {
 
     @Column(name = "datecreate")
     @Convert(converter = LocalDateAttributeConverter.class)
-    //@Temporal(TemporalType.TIMESTAMP)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
     private LocalDateTime dateCreate;
 
     private String user;

--- a/src/main/java/com/atable/alcholknowledge/model/CorkageStore.java
+++ b/src/main/java/com/atable/alcholknowledge/model/CorkageStore.java
@@ -1,5 +1,11 @@
 package com.atable.alcholknowledge.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
 import javax.naming.Name;
 import javax.persistence.*;
 import java.sql.Date;
@@ -30,6 +36,9 @@ public class CorkageStore {
 
     @Column (name = "date_update")
     @Convert (converter = LocalDateAttributeConverter.class)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
     private LocalDateTime dateUpdate;
 
     private String website;


### PR DESCRIPTION
## 개요
프론트엔드 서버로 데이터 송수신을 위한 api 추가
 
## 작업사항
- [x] 콜키지 매장 목록 조회를 위한 데이터 전송 api 추가 (api/corkage-store/list)
- [x] 사용자가 접수한 콜키지 매장 정보 저장을 위한 api 추가 (api/corkage-info/new)
 
## 변경로직
- 콜키지 매장 목록 조회 : 콜키지 매장 데이터를 HTTP 응답의 body 에 담아 클라이언트에게 전송
- 콜키지 매장 접수 : json 형식으로 HTTP 요청 body 에 담아온 접수 요청된 콜키지 매장 정보를 db에 저장