### PR TITLE
Do not throw error for registering duplicating corkageInfo

### DIFF
--- a/src/main/java/com/atable/alcoholknowledge/SpringConfig.java
+++ b/src/main/java/com/atable/alcoholknowledge/SpringConfig.java
@@ -40,7 +40,7 @@ public class SpringConfig {
 
     @Bean
     public CorkageStoreService corkageStoreService() {
-        return new CorkageStoreService(corkageStoreRepository());
+        return new CorkageStoreService(corkageInfoRepository(), corkageStoreRepository());
     }
     @Bean
     public CorkageInfoRepository corkageInfoRepository() {

--- a/src/main/java/com/atable/alcoholknowledge/repository/CorkageInfoRepository.java
+++ b/src/main/java/com/atable/alcoholknowledge/repository/CorkageInfoRepository.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 
 public interface CorkageInfoRepository {
     CorkageInfo save(CorkageInfo cInfo);
+    void checkAsCorkageStore(Long id);
     Optional<CorkageInfo> findById(Long id);
+    Long findByAddr(String Address);
     List<CorkageInfo> findAll();
 }

--- a/src/main/java/com/atable/alcoholknowledge/repository/JpaCorkageInfoRepository.java
+++ b/src/main/java/com/atable/alcoholknowledge/repository/JpaCorkageInfoRepository.java
@@ -21,9 +21,24 @@ public class JpaCorkageInfoRepository implements CorkageInfoRepository {
     }
 
     @Override
+    public void checkAsCorkageStore(Long id) {
+        CorkageInfo corkageInfo = em.find(CorkageInfo.class, id);
+        corkageInfo.setChecked(corkageInfo.isChecked() + 1);
+    }
+
+    @Override
     public Optional<CorkageInfo> findById(Long id) {
         CorkageInfo ckInfo = em.find(CorkageInfo.class, id);
         return Optional.ofNullable(ckInfo);
+    }
+
+    @Override
+    public Long findByAddr(String addr) {
+        List<CorkageInfo> result = em.createQuery("SELECT ckInfo FROM CorkageInfo AS ckInfo WHERE ckInfo.addr = :addr", CorkageInfo.class)
+                .setParameter("addr", addr)
+                .getResultList();
+        Long id = ((result.isEmpty() ? 0L : result.stream().findFirst().get().getId()));
+        return id;
     }
 
     @Override

--- a/src/main/java/com/atable/alcoholknowledge/repository/MemoryCkInfoRepository.java
+++ b/src/main/java/com/atable/alcoholknowledge/repository/MemoryCkInfoRepository.java
@@ -28,4 +28,13 @@ public class MemoryCkInfoRepository implements CorkageInfoRepository{
     public void clearStore() {
         store.clear();
     }
+
+    @Override
+    public void checkAsCorkageStore(Long id) {
+    }
+
+    @Override
+    public Long findByAddr(String Address) {
+        return 0L;
+    }
 }

--- a/src/main/java/com/atable/alcoholknowledge/service/CorkageStoreService.java
+++ b/src/main/java/com/atable/alcoholknowledge/service/CorkageStoreService.java
@@ -1,6 +1,7 @@
 package com.atable.alcoholknowledge.service;
 
 import com.atable.alcoholknowledge.model.CorkageStore;
+import com.atable.alcoholknowledge.repository.CorkageInfoRepository;
 import com.atable.alcoholknowledge.repository.CorkageStoreRepository;
 
 import javax.transaction.Transactional;
@@ -9,16 +10,22 @@ import java.util.Optional;
 
 @Transactional
 public class CorkageStoreService {
+    private final CorkageInfoRepository ckInfoRepository;
     private final CorkageStoreRepository ckStoreRepository;
 
-    public CorkageStoreService(CorkageStoreRepository ckStoreRepository) {
+    public CorkageStoreService(CorkageInfoRepository ckInfoRepository, CorkageStoreRepository ckStoreRepository) {
         this.ckStoreRepository = ckStoreRepository;
-
+        this.ckInfoRepository = ckInfoRepository;
     }
 
     public Long register(CorkageStore ckStore) {
-        validateDuplicateStore(ckStore);
-        ckStoreRepository.save(ckStore);
+        try{
+            validateDuplicateStore(ckStore);
+            ckStoreRepository.save(ckStore);
+        } catch (IllegalStateException e) {
+            Long ckInfoId = ckInfoRepository.findByAddr(ckStore.getAddr());
+            ckInfoRepository.checkAsCorkageStore(ckInfoId);
+        }
 
         return ckStore.getId();
     }

--- a/src/test/java/com/atable/alcoholknowledge/service/CorkageStoreServiceTest.java
+++ b/src/test/java/com/atable/alcoholknowledge/service/CorkageStoreServiceTest.java
@@ -1,6 +1,7 @@
 package com.atable.alcoholknowledge.service;
 
 import com.atable.alcoholknowledge.model.CorkageStore;
+import com.atable.alcoholknowledge.repository.MemoryCkInfoRepository;
 import com.atable.alcoholknowledge.repository.MemoryCkStoreRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,7 +19,7 @@ class CorkageStoreServiceTest {
     @BeforeEach
     void beforeEach() {
         ckStoreRepository = new MemoryCkStoreRepository();
-        ckStoreService = new CorkageStoreService(ckStoreRepository);
+        ckStoreService = new CorkageStoreService(new MemoryCkInfoRepository(), ckStoreRepository);
     }
 
     @AfterEach


### PR DESCRIPTION
## 개요
Admin 페이지에서 이미 등록된 매장과 일치(주소)하는 경우 처리 방식 변경
 
## 작업사항
   1. 이미 등록된 corkageInfo의 isChecked 값++
   2. 등록 시도한 corkageInfo 등록 처리하지 않음
   3. 기존 방식: 중복으로 등록되는 경우 에러 리턴
 
## 변경로직(optional)
`IllegalStateException`을 처리하는 로직 추가